### PR TITLE
fix broken links

### DIFF
--- a/src/content/about/radar.md
+++ b/src/content/about/radar.md
@@ -2,7 +2,7 @@
 layout: sub-navigation
 title: Tech Radar - Platforms, Tools, Languages, Frameworks and Techniques
 eleventyNavigation:
-  key: Tech Radar - Platforms, Tools, Languages, Frameworks and Techniques
+  key: Tech Radar
   parent: About
   order: 3
 ---

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -23,7 +23,7 @@ eleventyNavigation:
     <p class="govuk-body">Explore the many ways we encourage and support continuous learning and development.</p>
   </div>
     <div class="grid-card">
-    <h2 class="govuk-heading-m"><a href="ways-of-working/" class="govuk-link">How we work</a></h2>
+    <h2 class="govuk-heading-m"><a href="how-we-work/" class="govuk-link">How we work</a></h2>
     <p class="govuk-body">Explore events and approaches we use to work together more effectively.</p>
   </div>
     <div class="grid-card">

--- a/src/content/learning/index.md
+++ b/src/content/learning/index.md
@@ -16,7 +16,7 @@ At the Ministry of Justice (MoJ), we are committed to the continuous growth and 
 
 <div class="grid grid-cols-1 gap-1 pt-8">
   <div class="grid-card">
-    <h2 class="govuk-heading-m"><a href="data-engineer/" class="govuk-link">Analytics Engineering Pathway</a></h2>
+    <h2 class="govuk-heading-m"><a href="analytics-engineer/" class="govuk-link">Analytics Engineering Pathway</a></h2>
     <p class="govuk-body">Explore the materials and opportunities for learning on the Analytics Engineering Pathway</p>
   </div>
 <div class="grid grid-cols-1 gap-1 pt-8">


### PR DESCRIPTION
Fix broken links to:
`Learning/Analytics Engineering Pathway`
`Front page/How-we-work`
`about/tech-radar`