### PR TITLE
Final changes before merging handbook

### DIFF
--- a/src/content/about/management/people-management.md
+++ b/src/content/about/management/people-management.md
@@ -20,7 +20,7 @@ As a people manager, you would be expected to:
 - work with the people you manage to agree and monitor goals and objectives, in collaboration with their work manager
 - work with the people you manage to identify learning and development needs and opportunities
 - support the people you manage to access the right training, including apprenticeships and certifications
-- act as the primary contact for people you manage for all [people queries and issues](https://intranet.justice.gov.uk/guidance/hr/), including pay and expenses,leave, conduct and behaviour, absence management, and performance management
+- act as the primary contact for people you manage for all [people queries and issues](https://intranet.justice.gov.uk/guidance/hr/), including pay and expenses, leave, conduct and behaviour, absence management, and performance management
 - hold regular conversations with the people you manage
 - help the people you manage with their [Government Digital and Data assessments](https://justiceuk.sharepoint.com/:u:/r/sites/knowthething/SitePages/GDD-Capability%20Assessment.aspx?csf=1&web=1&e=4nsCvB), and ensure that they are getting the right opportunities to meet the criteria
 - support loans, secondments, and managed moves to meet development needs

--- a/src/content/innovation/time.md
+++ b/src/content/innovation/time.md
@@ -41,7 +41,7 @@ You could use your 10% time to contribute to open-source projects or build tools
 
 ### Participate in Hackathons and Firebreaks
 
-You can also engage in activities like hackathons: recently, we developed a [python package](https://github.com/moj-analytical-services/mojap-metadata) that allows users to read and alter our metadata schemas. You can download the files [here](https://pypi.org/project/mojap-metadata/)
+You can also engage in activities like hackathons: recently, we developed a [python package](https://github.com/moj-analytical-services/mojap-metadata) released on [pypi](https://pypi.org/project/mojap-metadata/) that allows users to read and alter our metadata schemas.
 
 You can join our firebreaks, where teams come together to tackle a specific challenge over a short period. These events encourage creativity, problem-solving, and cross-functional collaboration, and 10% time can support your participation.
 

--- a/src/content/innovation/time.md
+++ b/src/content/innovation/time.md
@@ -12,20 +12,20 @@ eleventyNavigation:
 ## What can you do in your 10% time?
 
 
-The scope of what you can do with your 10% time is quite broad, allowing you to focus on activities that align with both your personal interests and the directorate’s strategic goals. 
+The scope of what you can do with your 10% time is quite broad, allowing you to focus on activities that align with both your personal interests and the directorate’s strategic goals.
 
 Some common uses of 10% include:
 
 ### Personal Development and Learning
 
-You can use this time to build new skills or deepen existing ones. Whether it's [learning a new programming language](https://www.datacamp.com/courses-all?q=programming+languages&number=1&content_type=course&skill_level=Beginner) [understanding data literacy better](https://www.datacamp.com/blog/data-science-glossary) or enhancing your expertise in [cloud technologies](https://app.datacamp.com/learn/courses/aws-cloud-technology-and-services), 10% time provides a space for self-study and growth. 
+You can use this time to build new skills or deepen existing ones. Whether it's [learning a new programming language](https://www.datacamp.com/courses-all?q=programming+languages&number=1&content_type=course&skill_level=Beginner) [understanding data literacy better](https://www.datacamp.com/blog/data-science-glossary) or enhancing your expertise in [cloud technologies](https://app.datacamp.com/learn/courses/aws-cloud-technology-and-services), 10% time provides a space for self-study and growth.
 
 ### Explore Emerging Technologies and Tools
 
-Stay ahead of the curve by experimenting with emerging technologies or tools that aren't part of your usual workflow. For example, you could delve into [machine learning](https://www.datacamp.com/courses/understanding-machine-learning), new data visualisation platforms, or explore innovative ways to manage and analyse large datasets. 
+Stay ahead of the curve by experimenting with emerging technologies or tools that aren't part of your usual workflow. For example, you could delve into [machine learning](https://www.datacamp.com/courses/understanding-machine-learning), new data visualisation platforms, or explore innovative ways to manage and analyse large datasets.
 
 
-### Innovative Side Projects 
+### Innovative Side Projects
 
 10% time allows you to work on projects that might not fit into your usual responsibilities but could have a positive impact on the Ministry of Justice. This could be developing a prototype, automating a routine process, or brainstorming new methods for improving Data Analytics and Engineering.
 
@@ -41,7 +41,7 @@ You could use your 10% time to contribute to open-source projects or build tools
 
 ### Participate in Hackathons and Firebreaks
 
-You can also engage in activities like hackathons: recently, we developed a [python package]  (https://github.com/moj-analytical-services/mojap-metadata) that allows users to read and alter our metadata schemas. You can download the files [here](https://pypi.org/project/mojap-metadata/)   
+You can also engage in activities like hackathons: recently, we developed a [python package](https://github.com/moj-analytical-services/mojap-metadata) that allows users to read and alter our metadata schemas. You can download the files [here](https://pypi.org/project/mojap-metadata/)
 
 You can join our firebreaks, where teams come together to tackle a specific challenge over a short period. These events encourage creativity, problem-solving, and cross-functional collaboration, and 10% time can support your participation.
 


### PR DESCRIPTION
- The section `how-we-work/CaDeT` is empty. Do we want to remove it?