### PR TITLE
Update upload-pages-artifact version in deploy.yaml

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Build with Eleventy
         run: npm run-script build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3.0.1
   deploy:
     environment:
       name: github-pages


### PR DESCRIPTION
The current version of this action uses a now deprecated version of `upload-article`. Bumping to 3.x aligns to current versions.